### PR TITLE
Add `config` slash command

### DIFF
--- a/bot/src/Commands/Mod/Config.ts
+++ b/bot/src/Commands/Mod/Config.ts
@@ -1,0 +1,36 @@
+import {  ReaderCommand, ReaderInterface } from "reader-framework";
+
+export const command: ReaderInterface.ICommand = {
+    name: "config",
+    description: "Configure the bot settings",
+    type: 1,
+    options: [
+        {
+            name: "language",
+            description: "Configure the language used in this guild",
+            type: 1,
+            options: [
+                {
+                    name: "language",
+                    description: "The language to set",
+                    type: 3,
+                    required: true,
+                    /* @ts-ignore */
+                    choices: [
+                        {
+                            name: "English",
+                            value: "en"
+                        },
+                        {
+                            name: "Japanese",
+                            value: "ja"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    run: async (payload) => {
+        return new ReaderCommand(payload).configCommand();
+    }
+}

--- a/framework/lib/Commands/Command.ts
+++ b/framework/lib/Commands/Command.ts
@@ -21,6 +21,14 @@ export class ReaderCommand {
     }
 
     /**
+     * Executes a `config` command
+     * @returns {Promise<void>}
+     */
+    public configCommand() {
+        return CommandModules.configCommand(this.client, this.interaction);
+    }
+
+    /**
      * Executes a `ping` command
      * @returns  {Promise<void>}
      */

--- a/framework/lib/Commands/Modules/ConfigCommand.ts
+++ b/framework/lib/Commands/Modules/ConfigCommand.ts
@@ -1,0 +1,28 @@
+import { ReaderClient } from "../../Client";
+import { CommandInteraction, Constants, InteractionDataOptionsString, InteractionDataOptionsSubCommand, TextableChannel } from "eris";
+import { Utils } from "givies-framework";
+import { Util } from "../../Utils";
+import { TLocale } from "../../Types";
+import { GuildModel } from "../../Models";
+
+export function configCommand(client: ReaderClient, interaction: CommandInteraction<TextableChannel>) {
+    const args: { language?: TLocale } = {};
+
+    for (const option of (interaction.data.options[0] as InteractionDataOptionsSubCommand).options) {
+        args[(option as InteractionDataOptionsString).name] = (option as InteractionDataOptionsString).value;
+    }
+
+    if (args.language) {
+        GuildModel.findOneAndUpdate({ id: interaction.guildID }, { $set: { "settings.locale": args.language } }).exec();
+
+        const embed = new Utils.RichEmbed()
+            .setColor(client.config.BOT.COLOUR)
+            .setDescription(client.translateLocale(args.language, "mod.language.set", { language: Util.convertLocale(args.language) }));
+
+        return interaction.createMessage({
+            embeds: [embed],
+            flags: Constants.MessageFlags.EPHEMERAL
+        });
+    }
+}
+

--- a/framework/lib/Commands/Modules/index.ts
+++ b/framework/lib/Commands/Modules/index.ts
@@ -1,3 +1,4 @@
+export * from "./ConfigCommand";
 export * from "./PingCommand";
 export * from "./ReadCommand";
 export * from "./SearchCommand";


### PR DESCRIPTION
For now, the only available configurable setting is `language`. Probably more if I decided to add more customisable settings.