### PR TITLE
Handle API error correctly

### DIFF
--- a/framework/lib/Commands/Modules/ReadCommand.ts
+++ b/framework/lib/Commands/Modules/ReadCommand.ts
@@ -1,5 +1,5 @@
 import { ReaderClient } from "../../Client";
-import { ActionRow, CommandInteraction, TextableChannel } from "eris";
+import { ActionRow, CommandInteraction, Constants, TextableChannel } from "eris";
 import { API } from "nhentai-api";
 import { CookieJar } from "tough-cookie";
 import { HttpsCookieAgent } from "http-cookie-agent/http";
@@ -8,7 +8,7 @@ import { createReadPaginator } from "../../Modules/ReadPaginator";
 import { Utils } from "givies-framework";
 import moment from "moment";
 
-export function readCommand(client: ReaderClient, interaction: CommandInteraction<TextableChannel>) {
+export async function readCommand(client: ReaderClient, interaction: CommandInteraction<TextableChannel>) {
     const jar = new CookieJar();
     jar.setCookie(client.config.API.COOKIE, "https://nhentai.net/");
 
@@ -76,7 +76,18 @@ export function readCommand(client: ReaderClient, interaction: CommandInteractio
 
         interaction.createMessage({ components: [component], embeds: [embed] });
         createReadPaginator(client, book, interaction);
-    }).catch((err) => {
-        return client.logger.error({ message: err, subTitle: "NHentaiAPI::Book", title: "API" });
+    }).catch((err: Error) => {
+        if (err.message === "Request failed with status code 404") {
+            const embed = new Utils.RichEmbed()
+                .setColor(client.config.BOT.COLOUR)
+                .setDescription(client.translate("main.read.none", { id: args.id } ));
+
+            return interaction.createMessage({
+                embeds: [embed],
+                flags: Constants.MessageFlags.EPHEMERAL
+            });
+        }
+
+        return client.logger.error({ message: err.message, subTitle: "NHentaiAPI::Book", title: "API" });
     });
 }

--- a/framework/lib/Commands/Modules/ReadCommand.ts
+++ b/framework/lib/Commands/Modules/ReadCommand.ts
@@ -8,7 +8,7 @@ import { createReadPaginator } from "../../Modules/ReadPaginator";
 import { Utils } from "givies-framework";
 import moment from "moment";
 
-export async function readCommand(client: ReaderClient, interaction: CommandInteraction<TextableChannel>) {
+export function readCommand(client: ReaderClient, interaction: CommandInteraction<TextableChannel>) {
     const jar = new CookieJar();
     jar.setCookie(client.config.API.COOKIE, "https://nhentai.net/");
 

--- a/framework/lib/Commands/Modules/SearchCommand.ts
+++ b/framework/lib/Commands/Modules/SearchCommand.ts
@@ -23,7 +23,7 @@ export function searchCommand(client: ReaderClient, interaction: CommandInteract
         if (search.books.length === 0) {
             const embed = new Utils.RichEmbed()
                 .setColor(client.config.BOT.COLOUR)
-                .setDescription(client.translate("main.search.none"));
+                .setDescription(client.translate("main.search.none", { query: args.query } ));
 
             return interaction.createMessage({
                 embeds: [embed],

--- a/framework/lib/Commands/Modules/SearchSimilarCommand.ts
+++ b/framework/lib/Commands/Modules/SearchSimilarCommand.ts
@@ -23,7 +23,7 @@ export function searchSimilarCommand(client: ReaderClient, interaction: CommandI
         if (search.books.length === 0) {
             const embed = new Utils.RichEmbed()
                 .setColor(client.config.BOT.COLOUR)
-                .setDescription(client.translate("main.search.none"));
+                .setDescription(client.translate("main.search.empty"));
 
             return interaction.createMessage({
                 embeds: [embed],
@@ -61,7 +61,18 @@ export function searchSimilarCommand(client: ReaderClient, interaction: CommandI
             components: [component],
             embeds: [embed]
         });
-    }).catch((err: string) => {
-        return client.logger.error({ message: err, subTitle: "NHentaiAPI::SearchALike", title: "API" });
+    }).catch((err: Error) => {
+        if (err.message === "Request failed with status code 404") {
+            const embed = new Utils.RichEmbed()
+                .setColor(client.config.BOT.COLOUR)
+                .setDescription(client.translate("main.read.none", { id: args.id } ));
+
+            return interaction.createMessage({
+                embeds: [embed],
+                flags: Constants.MessageFlags.EPHEMERAL
+            });
+        }
+
+        return client.logger.error({ message: err.message, subTitle: "NHentaiAPI::SearchALike", title: "API" });
     });
 }


### PR DESCRIPTION
The bot should send an error message embed when encountering an API error. Errors like 404 not found will be displayed (excluding API Network-issue)